### PR TITLE
feat: persit the peer identity accross restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,13 @@ WORKDIR /app
 ENV GOPATH=/app/go
 RUN go install github.com/ipld/frisbii/cmd/frisbii@latest
 
+ADD entrypoint.sh entrypoint.sh
 ADD data data
 
 EXPOSE 3000
-ENTRYPOINT [ \
-  "/app/go/bin/frisbii", \
+ENTRYPOINT [ "/app/entrypoint.sh" ]
+
+CMD [ \
   "--announce=roots", \
   "--listen=:3000", \
   "--public-addr=https://frisbii.fly.dev:443", \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ docker rm -f frisbii && docker run -it --name frisbii -p 3000:3000 frisbii-on-fl
 
 Run `fly deploy` to update the Fly.io deployment.
 
+The peer identity (private key) is configured via the environment variable `PRIVATE_KEY`.
+
+The Fly.io secrets contain the private key for the following identity:
+
+```
+12D3KooWC8gXxg9LoJ9h3hy3jzBkEAxamyHEQJKtRmAuBuvoMzpr
+```
+
 ## CIDs
 
 ### random words

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+if [ "$PRIVATE_KEY" ]; then
+  # See https://github.com/ipld/frisbii/issues/132#issuecomment-2216295267
+  echo "Configuring private key from the environment secrets"
+  mkdir ~/.frisbii
+  echo "$PRIVATE_KEY" | xxd -r -p > ~/.frisbii/key
+else
+  echo "Private key not provided, Frisbii will create an ephemeral identity"
+fi
+
+echo "Starting frisbii" "$@"
+exec /app/go/bin/frisbii "$@"


### PR DESCRIPTION
- Read the private key from the environment variable `PRIVATE_KEY`.
- Add a Fly.io secret to provide the private key for our deployment

See https://github.com/ipld/frisbii/issues/132

Close https://github.com/filecoin-station/frisbii-on-fly/issues/1
